### PR TITLE
fix: Correct schema reference and typo in ground rules

### DIFF
--- a/docs/GroundRules.md
+++ b/docs/GroundRules.md
@@ -11,7 +11,7 @@
 - **Database**: PostgreSQL version 15 with existing schema and Drizzle ORM
 - **Development Philosophy**: API-first development approach
 - **API Validation**: All data validation must be enforced at the API level to support future agent communication
-- **Database Driven ORM**: Use Drizzle ORM with database driven philosophy for the backend - the Drizzle table definitions (Drizzle kit push) is the source of truth. Do not introduce new API properties that do not exist inn the database.
+- **Database Driven ORM**: Use Drizzle ORM with database driven philosophy for the backend - the Drizzle table definitions lib/db/schema.js are the source of truth. Do not introduce new API properties that do not exist in the schema
 
 ### Architecture
 


### PR DESCRIPTION
## Summary

Quick fix to correct documentation in the Ground Rules file.

## Changes

- **Schema Reference**: Updated reference from 'Drizzle kit push' to 'lib/db/schema.js' 
- **Typo Fix**: Corrected 'inn the database' to 'in the schema'
- **Clarification**: Makes it clear that the schema.js file is the source of truth for database structure

## Context

This clarifies that developers should refer to the actual schema file () rather than the Drizzle kit push command when understanding the database structure. The schema file contains the definitive table and column definitions that should be used as the source of truth.

Small but important fix for developer clarity and documentation accuracy.