### PR TITLE
docs: update README to task-blaster-oss

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ This application uses Docker Compose for easy local development. The setup inclu
 ### Step 1: Clone the Repository
 
 ```bash
-git clone https://github.com/michaelwitz/task-blaster.git
-cd task-blaster
+git clone https://github.com/michaelwitz/task-blaster-oss.git
+cd task-blaster-oss
 ```
 
 ### Step 2: Environment Configuration
@@ -354,7 +354,7 @@ For enterprise features and support, contact us about the paid subscription vers
 ### Monorepo Structure
 
 ```
-task-blaster/
+task-blaster-oss/
 ├── api/                 # Fastify API server
 │   ├── lib/db/         # Database schema and migrations
 │   ├── src/            # API source code

--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/michaelwitz/task-blaster.git"
+    "url": "git+https://github.com/michaelwitz/task-blaster-oss.git"
   },
   "keywords": [
     "agentic",
@@ -29,9 +29,9 @@
   "author": "Michael Woytowitz",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/michaelwitz/task-blaster/issues"
+    "url": "https://github.com/michaelwitz/task-blaster-oss/issues"
   },
-  "homepage": "https://github.com/michaelwitz/task-blaster#readme",
+  "homepage": "https://github.com/michaelwitz/task-blaster-oss#readme",
   "dependencies": {
     "@fastify/cors": "^11.1.0",
     "@fastify/multipart": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/michaelwitz/task-blaster.git"
+    "url": "git+https://github.com/michaelwitz/task-blaster-oss.git"
   },
   "keywords": [
     "agentic",


### PR DESCRIPTION
Updates README clone instructions and monorepo root path to the renamed repository (task-blaster-oss). No application code or UI changes. Follows Agent Ground Rules for PAT usage (temporary tokenized remote only for push).